### PR TITLE
Fix bug regarding running pip3 command

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -68,7 +68,7 @@ def run_pip(input_string):
     res = set()
     pip_options = [
         "pip3", "download",
-        input_string,
+        input_string.replace("=","=="),
         "-d", TMP_DIR
     ]
 


### PR DESCRIPTION
According to pip [documentation](https://pip.pypa.io/en/stable/user_guide/#installingPackages),  in order to install a specific version of  a package the  double equals operator(==) should be used: ``` python -m pip install SomePackage==1.0.4     # specific version  ```
On the code, the subprocess Popen method executes the corresponding pip command, but instead uses only a single equal operator. This pull request aims to fix this bug by replacing the subprocess call with the required double equal operator.