### PR TITLE
Implement Local Dependency Resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 pypi-resolver
 ===============
 
-This tool resolves Python dependencies by using `pip`.
+This tool resolves Python dependencies by using `pip` and `pip-compile`.
 It can be executed as a CLI tool, or it can be deployed as a Flask API.
 It accepts as input any string that can be resolved by pip.
+It also supports dependency resolution of local python projects, by parsing the requirements.txt file.
 
 Command Line Arguments
 ----------------------
-__You should always use at least one of -f or -i__
+__You should always use at least one of -f, -i or -r__
 
 ```
-usage: Resolve dependencies of PyPI packages [-h] [-i INPUT] [-o OUTPUT_FILE] [-f]
+usage: Resolve dependencies of PyPI packages [-h] [-i INPUT] [-r REQUIREMENTS_FILE] [-o OUTPUT_FILE] [-f]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -18,6 +19,9 @@ optional arguments:
                         Input should be a string of a package name or the names of multiple
                         packages separated by spaces. Examples: 'django' or
                         'django=3.1.3' or 'django wagtail'
+  -l LOCAL_PROJECT, --local-project LOCAL_PROJECT
+                        The path of the requirements.txt file. When specified, the
+                        dependencies of a local project are resolved
   -o OUTPUT_FILE, --output-file OUTPUT_FILE
                         File to save the output
   -f, --flask           Deploy flask api

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Command Line Arguments
 __You should always use at least one of -f, -i or -r__
 
 ```
-usage: Resolve dependencies of PyPI packages [-h] [-i INPUT] [-r REQUIREMENTS_FILE] [-o OUTPUT_FILE] [-f]
+usage: Resolve dependencies of PyPI packages [-h] [-i INPUT_PACKAGE] [-r REQUIREMENTS_FILE] [-o OUTPUT_FILE] [-f]
 
 optional arguments:
   -h, --help            show this help message and exit
-  -i INPUT, --input INPUT
-                        Input should be a string of a package name or the names of multiple
+  -i INPUT_PACKAGE, --input_package INPUT_PACKAGE
+                        Input package be a string of a package name or the names of multiple
                         packages separated by spaces. Examples: 'django' or
                         'django=3.1.3' or 'django wagtail'
   -l LOCAL_PROJECT, --local-project LOCAL_PROJECT

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ docker build -f Dockerfile -t pypi-resolver-api .
 docker run -p 5001:5000 pypi-resolver-api
 ```
 
+### Dependency Resolution Endpoint for PyPI Packages
+
 * Request format
 
 ```
@@ -114,6 +116,87 @@ curl "http://localhost:5001/dependencies/django/3.1.3"
   {
     "product": "pytz",
     "version": "2021.1"
+  }
+]
+```
+### Dependency Resolution Endpoint for a local Python Project (not distributed through PIP).
+
+
+* Request format
+
+```
+url: http://localhost:5001/resolve_dependencies
+```
+
+* Usage
+
+Should recieve through a POST Request a list of all the project's dependencies as defined on the requirements.txt file, separated by commas 
+
+* Example request using curl:
+
+```bash
+ curl -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache" -d '[flask, pip-tools]' "http://localhost:5001/resolve_dependencies"
+```
+
+* Output format:
+ 
+ ```json
+[
+  {
+    "product": "tomli", 
+    "version": "2.0.1"
+  }, 
+  {
+    "product": "pip", 
+    "version": "22.0.4"
+  }, 
+  {
+    "product": "zipp", 
+    "version": "3.7.0"
+  }, 
+  {
+    "product": "Jinja2", 
+    "version": "3.1.1"
+  }, 
+  {
+    "product": "setuptools", 
+    "version": "61.2.0"
+  }, 
+  {
+    "product": "Werkzeug", 
+    "version": "2.1.0"
+  }, 
+  {
+    "product": "Flask", 
+    "version": "2.1.0"
+  }, 
+  {
+    "product": "importlib-metadata", 
+    "version": "4.11.3"
+  }, 
+  {
+    "product": "pep517", 
+    "version": "0.12.0"
+  }, 
+  {
+    "product": "itsdangerous", 
+    "version": "2.1.2"
+  }, 
+  {
+    "product": "click", 
+    "version": "8.1.0"
+  }, 
+  {
+    "product": "MarkupSafe", 
+    "version": "2.1.1"
+  }, 
+  {
+    "product": "pip-tools", 
+    "version": "6.5.1"
+  }, 
+  {
+    "product": "wheel", 
+    "version": "0.37.1"
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-pypi-resolver
+Fasten PyPI Resolver
 ===============
 
 This tool resolves Python dependencies by using `pip`.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ curl "http://localhost:5001/dependencies/django/3.1.3"
   }
 ]
 ```
-### Dependency Resolution Endpoint for a local Python Project (not distributed through PIP).
+### Dependency Resolution Endpoint for multiple dependencies.
 
 
 * Request format
@@ -130,7 +130,7 @@ url: http://localhost:5001/resolve_dependencies
 
 * Usage
 
-Should recieve through a POST Request a list of all the project's dependencies as defined on the requirements.txt file, separated by commas 
+  Should recieve through a POST Request a list of dependencies as defined on the requirements.txt file, separated by commas 
 
 * Example request using curl:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 pypi-resolver
 ===============
 
-This tool resolves Python dependencies by using `pip` and `pip-compile`.
+This tool resolves Python dependencies by using `pip`.
 It can be executed as a CLI tool, or it can be deployed as a Flask API.
 It accepts as input any string that can be resolved by pip.
 It also supports dependency resolution of local python projects, by parsing the requirements.txt file.
@@ -19,9 +19,10 @@ optional arguments:
                         Input package be a string of a package name or the names of multiple
                         packages separated by spaces. Examples: 'django' or
                         'django=3.1.3' or 'django wagtail'
-  -l LOCAL_PROJECT, --local-project LOCAL_PROJECT
-                        The path of the requirements.txt file. When specified, the
-                        dependencies of a local project are resolved
+  -r REQUIREMENTS_FILE, --requirements-file REQUIREMENTS_FILE
+                        The path of the requirements.txt file.
+                        When specified, the dependencies of a local project are
+                        resolved
   -o OUTPUT_FILE, --output-file OUTPUT_FILE
                         File to save the output
   -f, --flask           Deploy flask api

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ usage: Resolve dependencies of PyPI packages [-h] [-i INPUT_PACKAGE] [-r REQUIRE
 
 optional arguments:
   -h, --help            show this help message and exit
-  -i INPUT_PACKAGE, --input_package INPUT_PACKAGE
+  -i INPUT_PACKAGE, --input-package INPUT_PACKAGE
                         Input package be a string of a package name or the names of multiple
                         packages separated by spaces. Examples: 'django' or
                         'django=3.1.3' or 'django wagtail'

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -212,7 +212,7 @@ def get_parser():
     )
     parser.add_argument(
         '-i',
-        '--input_package',
+        '--input-package',
         type=str,
         help=(
             "Input package should be a string of a package name or the names of "
@@ -259,7 +259,7 @@ def main():
         message = "You cannot use any other argument with --flask option."
         raise parser.error(message)
     if (input_string and requirements_path):
-        message = "You should always use only one of  --input_package or --local-project when you want to run the cli."
+        message = "You should always use only one of  --input-package or --local-project when you want to run the cli."
         raise parser.error(message)
     if (not flask and not input_string and not requirements_path):
         message = "You should always use --input or --local-project option when you want to run the cli."

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -133,7 +133,6 @@ def run_pip(input_string, is_local_resolution):
 
     return True, res
 
-
 ###### FLASK API ######
 app = flask.Flask("api")
 app.config["DEBUG"] = True
@@ -144,7 +143,7 @@ def home():
     <p>An API for resolving PyPI dependencies.</p>
     <p>API Endpoint for PyPI Packages: /dependencies/{packageName}/{version}<p>
     <p><b>Note</b>: The {version} path parameter is optional <p>
-    <p>API Endpoint for Local Projects: /resolve_local_dependencies<p>
+    <p>API Endpoint for Local Projects: /resolve_dependencies<p>
     <p><b>Note</b>: Should recieve through a POST Request a list of all the project's dependencies as defined on the requirements.txt file, separated by commas <p>
     '''
 
@@ -178,8 +177,8 @@ def resolver_api_with_version(packageName, version):
 
     return jsonify(get_response_for_api(status, res))
 
-@app.route('/resolve_local_dependencies', methods=['POST'])
-def local_resolver():
+@app.route('/resolve_dependencies', methods=['POST'])
+def multiple_dependencies_resolver_api():
     try:
         request_data=str(request.data.decode("utf-8")).replace("[","").replace("]","")
         requirements = request_data.split(",")

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -186,6 +186,7 @@ def local_resolver():
         create_requirements_file(requirements)
         
     except Exception as e:
+        delete_requirements_file()
         return str(e)
     status, res = run_pip(TMP_REQUIREMENTS_TXT, True)
     

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -282,9 +282,9 @@ def main():
 
     if output_file:
         with open(output_file, 'w') as outfile:
-            json.dump(get_response(input_string, status, res), outfile)
+            json.dump(get_response(input_string, status, res), outfile, indent=4)
     else:
-        print(json.dumps(get_response(input_string, status, res)))
+        print(json.dumps(get_response(input_string, status, res), indent=4))
 
 
 if __name__ == "__main__":

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -144,7 +144,7 @@ def home():
     <p>API Endpoint for PyPI Packages: /dependencies/{packageName}/{version}<p>
     <p><b>Note</b>: The {version} path parameter is optional <p>
     <p>API Endpoint for Local Projects: /resolve_dependencies<p>
-    <p><b>Note</b>: Should recieve through a POST Request a list of all the project's dependencies as defined on the requirements.txt file, separated by commas <p>
+    <p><b>Note</b>: Should recieve through a POST Request a list of multiple dependencies as defined on the requirements.txt file, separated by commas <p>
     '''
 
 

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -126,6 +126,7 @@ def run_pip_compile(filepath):
     res = set()
     pip_options = [
         "pip-compile", filepath,
+        "-n"
     ]
     cmd = sp.Popen(pip_options, stdout=sp.PIPE, stderr=sp.STDOUT)
     stdout, _ = cmd.communicate()
@@ -138,7 +139,7 @@ def run_pip_compile(filepath):
         if line.startswith("Could not find"):
             err = line
             break
-        if (re.match("^[a-zA-Z]+.*", line)):
+        if (re.match("^[a-zA-Z]+.*", line) and (not line.startswith("Dry-run"))):
             package, version = line.split("==")
             res.add((package, version))
     

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -24,7 +24,6 @@ import json
 import argparse
 import subprocess as sp
 import flask
-import sys
 import re
 import os
 from pkginfo import Wheel, SDist, BDist
@@ -222,20 +221,20 @@ def get_parser():
         )
     )
     parser.add_argument(
+        '-r',
+        '--requirements-file',
+        type=str,
+        help=(
+            "The path of the requirements.txt file. "
+            "When specified, the dependencies of a local project are resolved"
+        )
+    )   
+    parser.add_argument(
         '-o',
         '--output-file',
         type=str,
         help="File to save the output"
     )
-    parser.add_argument(
-        '-l',
-        '--local-project',
-        type=str,
-        help=(
-            "The path of the requirements.txt file. "
-            "When given, the dependencies of a local project are resolved"
-        )
-    )   
     parser.add_argument(
         '-f',
         '--flask',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask
 pkginfo
+pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 flask
 pkginfo
-pip-tools


### PR DESCRIPTION
## Description
This PR aims to extend PyPI Resolver to support resolution of multiple dependencies by receiving as input the `requirements.txt` file of a project and resolving all its transitive dependencies with the use of `pip`. 
It also introduces a new REST-API endpoint that recieves as input a list with all the dependencies defined on a `requirements.txt` file and resolves its dependencies accordingly.

## Motivation and context
Currently, PyPI resolver only supported dependency resolution of PyPI packages distributed through PIP.
Previously,  python projects which were being developed locally and were not distributed through pip could not be  processed through the tool. 
Now, with this change, developers can employ the PyPI plugin to resolve the dependencies of their local project by passing the corresponding `requirements.txt` file
This change also aims to support the development of the [PyPI Plugin](https://github.com/fasten-project/fasten-pypi-plugin) which needs to perform local dependency resolution 

## Testing
Tested the resolver through passing a dummy `requirements.txt` file and it had the expected behaviour.
Also tested the new rest-api endpoint locally and through Docker and it also had the expected behaviour

## Task list  
- [x] Implement dependency resolution of an input`requirements.txt` file
- [x] Implement the corresponding REST-API endpoint
- [x] Document multiple dependency resolution

